### PR TITLE
Allow changing @Future::HTTP::loops more easily

### DIFF
--- a/lib/Future/HTTP.pm
+++ b/lib/Future/HTTP.pm
@@ -57,7 +57,8 @@ but has not materialized yet.
 
 our $VERSION = '0.09';
 
-our @loops = (
+our @loops;
+push @loops, (
     ['IO/Async.pm'    => 'Future::HTTP::NetAsync' ],
     ['Mojo/IOLoop.pm' => 'Future::HTTP::Mojo' ],
     ['AnyEvent.pm'    => 'Future::HTTP::AnyEvent'],

--- a/t/02-changedefault1.t
+++ b/t/02-changedefault1.t
@@ -1,0 +1,12 @@
+#!perl -w
+use strict;
+use warnings;
+use Test::More tests=>1;
+
+BEGIN {
+    unshift @Future::HTTP::loops, ['Test/More.pm' => 'Config'];
+}
+use Future::HTTP;
+
+is( Future::HTTP->best_implementation(), 'Config', "changed default backend (pre)");
+

--- a/t/02-changedefault2.t
+++ b/t/02-changedefault2.t
@@ -1,0 +1,12 @@
+#!perl -w
+use strict;
+use warnings;
+use Test::More tests=>1;
+
+use Future::HTTP;
+BEGIN {
+    unshift @Future::HTTP::loops, ['Test/More.pm' => 'Config'];
+}
+
+is( Future::HTTP->best_implementation(), 'Config', "changed default backend (post)");
+


### PR DESCRIPTION
Previously, modifications made to `@Future::HTTP::loops` would be
clobbered when the module was loaded (like in `t/02-changedefault1.t`)