### PR TITLE
Proposal: Add $ua->is_async method

### DIFF
--- a/lib/Future/HTTP.pm
+++ b/lib/Future/HTTP.pm
@@ -127,7 +127,16 @@ sub best_implementation( $class, @candidates ) {
     return $default;
 };
 
-1;
+=head2 C<< $ua->is_async() >>
+
+Returns true if the selected backend is asynchronous, false if it is
+synchronous.
+
+=cut
+
+sub is_async {
+    die "method is_async must be overloaded by subclass\n";
+}
 
 # We support the L<AnyEvent::HTTP> API first
 

--- a/lib/Future/HTTP/AnyEvent.pm
+++ b/lib/Future/HTTP/AnyEvent.pm
@@ -26,6 +26,8 @@ sub BUILDARGS( $class, %options ) {
     return {}
 }
 
+sub is_async { !0 }
+
 sub future_from_result {
     my( $self, $body, $headers ) = @_;
 
@@ -74,6 +76,10 @@ using L<AnyEvent::HTTP>.
     my $ua = Future::HTTP::AnyEvent->new();
 
 Creates a new instance of the HTTP client.
+
+=head2 C<< $ua->is_async() >>
+
+Returns true, because this backend is asynchronous.
 
 =head2 C<< $ua->http_get($url, %options) >>
 

--- a/lib/Future/HTTP/Mojo.pm
+++ b/lib/Future/HTTP/Mojo.pm
@@ -43,6 +43,8 @@ sub BUILDARGS {
     }
 }
 
+sub is_async { !0 }
+
 sub _ae_from_mojolicious( $self, $tx ) {
     # Convert the result back to a future
     my $res = $tx->res;
@@ -122,6 +124,10 @@ sub http_post($self,$url,$body,%options) {
     my $ua = Future::HTTP::Mojo->new();
 
 Creates a new instance of the HTTP client.
+
+=head2 C<< $ua->is_async() >>
+
+Returns true, because this backend is asynchronous.
 
 =head2 C<< $ua->http_get($url, %options) >>
 

--- a/lib/Future/HTTP/NetAsync.pm
+++ b/lib/Future/HTTP/NetAsync.pm
@@ -50,6 +50,8 @@ sub BUILDARGS {
     }
 }
 
+sub is_async { !0 }
+
 sub _ae_from_netasync( $self, $res ) {
     # Convert the result back to the AnyEvent format
     my( $body )        = $res->content;
@@ -128,6 +130,10 @@ sub http_post($self,$url,$body,%options) {
     my $ua = Future::HTTP::NetAsync->new();
 
 Creates a new instance of the HTTP client.
+
+=head2 C<< $ua->is_async() >>
+
+Returns true, because this backend is asynchronous.
 
 =head2 C<< $ua->http_get($url, %options) >>
 

--- a/lib/Future/HTTP/Tiny.pm
+++ b/lib/Future/HTTP/Tiny.pm
@@ -42,6 +42,8 @@ sub BUILDARGS {
     }
 }
 
+sub is_async { !1 }
+
 sub _ae_from_http_tiny( $self, $result, $url ) {
     # Convert the result back to a future
     my( $body )        = delete $result->{content};
@@ -123,6 +125,10 @@ sub http_post($self,$url,$body,%options) {
     my $ua = Future::HTTP::Tiny->new();
 
 Creates a new instance of the HTTP client.
+
+=head2 C<< $ua->is_async() >>
+
+Returns false, because this backend is synchronous.
 
 =head2 C<< $ua->http_get($url, %options) >>
 

--- a/lib/Future/HTTP/Tiny/Paranoid.pm
+++ b/lib/Future/HTTP/Tiny/Paranoid.pm
@@ -46,6 +46,10 @@ You can set up the whitelist and blacklist through the global accessors:
 
 Creates a new instance of the HTTP client.
 
+=head2 C<< $ua->is_async() >>
+
+Returns false, because this backend is synchronous.
+
 =head2 C<< $ua->http_get($url, %options) >>
 
     $ua->http_get('http://example.com/',

--- a/t/01-anyevent-http.t
+++ b/t/01-anyevent-http.t
@@ -35,6 +35,7 @@ my $server = Test::HTTP::LocalServer->spawn(
 );
 
 my $ua = Future::HTTP::AnyEvent->new();
+ok $ua->is_async, 'is_async is true';
 my $url = $server->url;
 
 my ($body,$headers) = $ua->http_get($url)->get;

--- a/t/01-http-tiny-paranoid.t
+++ b/t/01-http-tiny-paranoid.t
@@ -16,7 +16,7 @@ my $err = $@;
 if( !$ok) {
     plan skip_all => "Couldn't load Future::HTTP::Tiny::Paranoid: $err";
 };
-plan tests => 10;
+plan tests => 11;
 
 delete @ENV{ qw[
     HTTP_PROXY
@@ -46,6 +46,7 @@ my $h = $url->host;
 HTTP::Tiny::Paranoid->whitelisted_hosts([ $h, '127.0.0.1' ]);
 
 my $ua = Future::HTTP::Tiny::Paranoid->new();
+ok !$ua->is_async, 'is_async is false';
 
 my ($body,$headers) = $ua->http_get($url)->get;
 like $headers->{Status}, qr/2../, "Retrieve URL using HTTP::Tiny::Paranoid backend";

--- a/t/01-http-tiny.t
+++ b/t/01-http-tiny.t
@@ -9,7 +9,7 @@ use Test::HTTP::LocalServer;
 use Future::HTTP::Tiny;
 use HTTP::Tiny;
 
-plan tests => 10;
+plan tests => 11;
 my $server = Test::HTTP::LocalServer->spawn(
     #debug => 1
 );
@@ -28,6 +28,7 @@ delete @ENV{ qw[
 
 diag( "Version of HTTP::Tiny: " . HTTP::Tiny->VERSION );
 my $ua = Future::HTTP::Tiny->new();
+ok !$ua->is_async, 'is_async is false';
 my $url = $server->url;
 
 my ($body,$headers) = $ua->http_get($url)->get;

--- a/t/01-mojo.t
+++ b/t/01-mojo.t
@@ -17,7 +17,7 @@ if( !$ok) {
     exit;
 };
 
-plan tests => 11;
+plan tests => 12;
 
 delete @ENV{ qw[
     HTTP_PROXY
@@ -38,6 +38,7 @@ my $server = Test::HTTP::LocalServer->spawn(
 );
 
 my $ua = Future::HTTP::Mojo->new();
+ok $ua->is_async, 'is_async is true';
 my $url = "" . $server->url; # Mojolicious wants a string or a Mojo::URL, not a URI::URL :-/
 
 my ($body,$headers) = $ua->http_get($url)->get;

--- a/t/01-netasync.t
+++ b/t/01-netasync.t
@@ -16,7 +16,7 @@ if( !$ok) {
     plan skip_all => "Couldn't load Net::Async::HTTP: $err";
     exit;
 };
-plan tests => 10;
+plan tests => 11;
 
 
 delete @ENV{ qw[
@@ -38,6 +38,7 @@ my $server = Test::HTTP::LocalServer->spawn(
 );
 
 my $ua = Future::HTTP::NetAsync->new();
+ok $ua->is_async, 'is_async is true';
 my $url = $server->url;
 
 my ($body,$headers) = $ua->http_get($url)->get;


### PR DESCRIPTION
This allows one to write e.g.
```perl
my $ua = Future::HTTP->new();
warn "UA is synchronous, requests are blocking"
    unless $ua->is_async;
```