### PR TITLE
Call on_http_response rather than clobber the contents

### DIFF
--- a/lib/Future/HTTP/Handler.pm
+++ b/lib/Future/HTTP/Handler.pm
@@ -17,7 +17,7 @@ has 'on_http_response' => (
 );
 
 sub http_response_received( $self, $res, $body, $headers ) {
-    $self->on_http_response( $res, $body, $headers )
+    $self->on_http_response->( $res, $body, $headers )
         if $self->on_http_response;
     if( $headers->{Status} =~ /^[23]../ ) {
         $body = $self->decode_content( $body, $headers );


### PR DESCRIPTION
I'd planned to use the `on_http_response` callback to get the actual body contents on errors (status >= 400) rather than settling for the hard coded string on `$res->fail( ... )`.

If I'm misunderstanding that this should be a coderef, ignore this PR.